### PR TITLE
feat: Allow custom selection of action buttons

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -161,6 +161,20 @@ class _HomePageState extends State<HomePage> {
                     ),
                   ),
                   _buildDemoButton(
+                    title: "Enabled Icons Only",
+                    subtitle: "Only show camera switch and torch.",
+                    scanner: AiBarcodeScanner(
+                      galleryButtonType: GalleryButtonType.icon,
+                      enabledActionButtons: const {
+                        ScannerAction.cameraSwitch,
+                        ScannerAction.torch,
+                      },
+                      onDetect: (BarcodeCapture capture) {
+                        /// Do something with the barcode
+                      },
+                    ),
+                  ),
+                  _buildDemoButton(
                     title: "None Gallery Button",
                     subtitle: "Shows no gallery button.",
                     scanner: AiBarcodeScanner(


### PR DESCRIPTION
### What
This PR fixes [#167](https://github.com/itsarvinddev/barcode_scanner/issues/167).

### Why
Setting `GalleryButtonType.none` hides **all** action buttons (torch and camera switch included).  
It was requested to implement a way to disable only the gallery button while keeping other controls visible.

### How
Introduced a new `ScannerAction` enum and `enabledActionButtons` parameter, allowing users to specify exactly which icons should be displayed.  
For example:
```dart
AiBarcodeScanner(
    galleryButtonType: GalleryButtonType.icon,
    enabledActionButtons: const {
      ScannerAction.cameraSwitch,
      ScannerAction.torch,
    },
    onDetect: (BarcodeCapture capture) {
      /// Do something with the barcode
    },
  )
```